### PR TITLE
- Fixed issue where ghi would forcefully timeout-quit on ircds that d…

### DIFF
--- a/ghi/irc.py
+++ b/ghi/irc.py
@@ -121,7 +121,7 @@ class IRC(object):
         while True:
             text = self.getText()
             logging.debug(text)
-            ack = re.search(r'(.*)QUIT :Client Quit(.*)', text, re.MULTILINE)
+            ack = re.search(r'(.*)ERROR :Closing Link(.*)', text, re.IGNORECASE | re.MULTILINE)
             if ack:
                 break
             elif tries > 15:


### PR DESCRIPTION
…on't send a QUIT back to clients that issued a QUIT. Plus one cannot rely on the quit message being "QUIT: Client Quit". Apparently ghi has only been tested on ratbox based ircds. Better to rely on the standard ERROR that's sent by the server upon acknowledging a client QUIT.