### PR TITLE
Remove newlines from base64-encoded auth string

### DIFF
--- a/ghi/irc.py
+++ b/ghi/irc.py
@@ -85,7 +85,7 @@ class IRC(object):
             password=password
         )
         auth = base64.encodestring(auth.encode("UTF-8"))
-        auth = auth.decode("UTF-8").rstrip("\n")
+        auth = auth.decode("UTF-8").replace("\n", "")
         self.irc.send(bytes("AUTHENTICATE "+auth+"\r\n", "UTF-8"))
         self.waitAndSee(r'(.*)903(.*):SASL authentication successful(.*)')
         self.irc.send(bytes("CAP END\r\n", "UTF-8"))


### PR DESCRIPTION
[base64.encode() adds newlines every 76 characters](https://docs.python.org/3.6/library/base64.html#base64.encode) as per RFC 2045, but SASL auth needs a line without newlines, so a long password results in a login failure. This change strips newlines from the base64 string before sending.