### PR TITLE
add systemd-compatible logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,7 @@ $ python3 ghi/server.py --port 8080
 _Make sure your `PYTHONPATH` is set to your Ghi project directory._
 
 I have [provided an example service file](examples/ghi.service.md) to use with systemd to make starting/stopping Ghi easier.
+To use systemd's journal logging you can add the `--systemd` argument in the command line.
 
 # Configuration
 

--- a/examples/ghi.service.md
+++ b/examples/ghi.service.md
@@ -1,6 +1,6 @@
 # systemd
 
-Below is an example of a systemd service file for Ghi. If you are running Ghi on your own server, this allows you to manage the Ghi process with systemd. This example will start Ghi with it listening on port `8080` and write its logs to the `/var/log/ghi.log` file.
+Below is an example of a systemd service file for Ghi. If you are running Ghi on your own server, this allows you to manage the Ghi process with systemd. This example will start Ghi with it listening on port `8080` and write its logs to systemd's journal logging system (accessible by `systemctl status ghi` for the last output and `journalctl -u ghi` for the log in full).
 
 You can then start and stop it like so:
 
@@ -25,7 +25,7 @@ Type=simple
 User=ubuntu
 WorkingDirectory=/home/ubuntu/ghi
 EnvironmentFile=/etc/default/ghi
-ExecStart=/bin/bash -c "PYTHONPATH="/home/ubuntu/ghi/ghi:$PYTHONPATH" python3 /home/ubuntu/ghi/ghi/server.py --port 8080 &>> /var/log/ghi.log
+ExecStart=/bin/bash -c "PYTHONPATH="/home/ubuntu/ghi/ghi:$PYTHONPATH" python3 /home/ubuntu/ghi/ghi/server.py --port 8080 --systemd
 Restart=on-failure
 RestartSec=3
 
@@ -33,6 +33,7 @@ RestartSec=3
 WantedBy=multi-user.target
 ```
 
-_You might need to create the log file first because the user might not have permissions to /var/log_
+If you want you can redirect the log-output to the `/var/log/ghi.log` file by substituting `--systemd` with `&>> /var/log/ghi.log`.
+_In that case you might need to create the log file first because the user might not have permissions to /var/log_
 
 With this Service file, you can also set your environment variables in the `/etc/default/ghi` file and they will be automatically exported on start.

--- a/ghi/configuration.py
+++ b/ghi/configuration.py
@@ -132,7 +132,7 @@ def getConfiguration():
         if "debug" in config:
             debug = config["debug"]
             if type(debug) is not bool:
-                raise TypeError("'pools' is not a boolean")
+                raise TypeError("'debug' is not a boolean")
         else:
             debug = False
 

--- a/ghi/ghilogging.py
+++ b/ghi/ghilogging.py
@@ -1,0 +1,60 @@
+import logging
+import sys
+
+
+class SystemdHandler(logging.Handler):
+    PREFIX = {
+        # EMERG <0>
+        # ALERT <1>
+        logging.CRITICAL: "<2>",
+        logging.ERROR: "<3>",
+        logging.WARNING: "<4>",
+        # NOTICE <5>
+        logging.INFO: "<6>",
+        logging.DEBUG: "<7>",
+        logging.NOTSET: "<7>"
+    }
+
+    def __init__(self, stream=sys.stdout):
+        self.stream = stream
+        logging.Handler.__init__(self)
+
+    def emit(self, record):
+        try:
+            msg = self.PREFIX[record.levelno] + self.format(record) + "\n"
+            self.stream.write(msg)
+            self.stream.flush()
+        except Exception: 
+            self.handleError(record)
+
+
+def setup_server_logging(mode, debug=None):
+    root_logger = logging.getLogger()
+    root_logger.setLevel("INFO")
+    mode = mode.lower() 
+
+    # AWS Lambda configures the logger before executing this script
+    # We want to remove their configurations and set our own
+    log = logging.getLogger()
+    if log.handlers:
+        for handler in log.handlers:
+            log.removeHandler(handler)
+
+    if mode == 'systemd':
+        # replace handler with systemd one
+        root_logger.addHandler(SystemdHandler())
+    if mode == 'aws':
+        logging.basicConfig(
+                level=logging.INFO,
+                format="%(message)s"
+            )
+    if mode == 'plain':
+        logging.basicConfig(
+            level=logging.INFO,
+            format="%(asctime)s [ghi] %(message)s",
+            datefmt="%Y-%m-%d %H:%M:%S"
+        )
+
+    if debug:
+        # Enable debug if set in config
+        logging.getLogger().setLevel(logging.DEBUG)


### PR DESCRIPTION
Because systemd's own logging system is more conventional and convenient than using `&>> /some/where/ghi.log` I've added the means to do so in a seperate module (also for refactoring of logging configuration in index.py and server.py).