### PR TITLE
Replaced deprecated base64.encodestring with base64.encodebytes

### DIFF
--- a/ghi/irc.py
+++ b/ghi/irc.py
@@ -84,7 +84,7 @@ class IRC(object):
             nick=nick,
             password=password
         )
-        auth = base64.encodestring(auth.encode("UTF-8"))
+        auth = base64.encodebytes(auth.encode("UTF-8"))
         auth = auth.decode("UTF-8").replace("\n", "")
         self.irc.send(bytes("AUTHENTICATE "+auth+"\r\n", "UTF-8"))
         self.waitAndSee(r'(.*)903(.*):SASL authentication successful(.*)')


### PR DESCRIPTION
Fixes #12.

encodebytes was introduced in version 3.1 so it should be widely supported by anyone running python3