### PR TITLE
Made message check for authentication flow more permissive

### DIFF
--- a/ghi/irc.py
+++ b/ghi/irc.py
@@ -77,7 +77,7 @@ class IRC(object):
         self.irc.send(bytes("CAP REQ :sasl\r\n", "UTF-8"))
         self.waitAndSee(r'(.*)CAP(.*)ACK(.*)')
         self.irc.send(bytes("AUTHENTICATE PLAIN\r\n", "UTF-8"))
-        self.waitAndSee(r'(.*)AUTHENTICATE \+(.*)')
+        self.waitAndSee(r'(.*)AUTHENTICATE(.*)')
         auth = (
             "{nick}\0{nick}\0{password}"
         ).format(


### PR DESCRIPTION
Fixes: #16 

Makes the message ghi looks for more permissive as now there appears to be an extra colon from freenode.