### PR TITLE
Made the final message check more permissive

### DIFF
--- a/ghi/irc.py
+++ b/ghi/irc.py
@@ -171,7 +171,7 @@ def sendMessages(pool, messages):
             text = irc.getText()
             for line in text.split('\r'):
                 logging.debug(line.rstrip())
-            if re.search(r'(.*)End of /NAMES list(.*)', text, re.MULTILINE):
+            if re.search(r'(.*)End of(.*)', text, re.MULTILINE):
                 break
             elif sendTries > 120:
                 # If tried 120 times and no match, raise error


### PR DESCRIPTION
Feels like a bit of a hacky way to check if a message has been delivered but rather than completely rework it, this PR just makes the check more permissive which now works on freenode. The new message that Freenode prints is `End of message of the day`. This permissive regex will match both the old and new.

Fixes #20 