### PR TITLE
Improved exception handling for unexpected and malformed messages

### DIFF
--- a/ghi/ghimastodon.py
+++ b/ghi/ghimastodon.py
@@ -71,6 +71,10 @@ def login(pool):
 def sendToots(pool, messages):
     try:
         mastodon = login(pool)
+
+        for message in messages:
+            mastodon.toot(message)
+
     except MastodonIllegalArgumentError as e:
         errorMessage = "Mastodon - Probably the password for Mastodon in the configfile is not correct"
         logging.error(errorMessage)
@@ -83,9 +87,6 @@ def sendToots(pool, messages):
             })
         }
 
-    try:
-        for message in messages:
-            mastodon.toot(message)
     except Exception as e:
         errorMessage = "Mastodon - There was a problem sending messages to Mastodon" 
         logging.error(errorMessage)

--- a/ghi/server.py
+++ b/ghi/server.py
@@ -80,15 +80,21 @@ class TaskQueue(queue.Queue):
 
     def worker(self):
         while True:
-            item, args, kwargs = self.get()
-            logging.info("Start UUID: %s" % args[0]['uuid'])
-            logging.info("{} {} ({})".format(args[0]['httpMethod'], args[0]['path'], args[0]['requesterIp']))
-            response = item(*args, **kwargs)
-            logging.info("")
-            logging.info("Response:")
-            logging.info(response)
-            logging.info("Stop UUID: %s" % args[0]['uuid'])
-            logging.info("")
+            try:
+                item, args, kwargs = self.get()
+                logging.info("Start UUID: %s" % args[0]['uuid'])
+                logging.info("{} {} ({})".format(args[0]['httpMethod'], args[0]['path'], args[0]['requesterIp']))
+                response = item(*args, **kwargs)
+                logging.info("")
+                logging.info("Response:")
+                logging.info(response)
+                logging.info("Stop UUID: %s" % args[0]['uuid'])
+                logging.info("")
+            except Exception as e:
+                errorMessage = "Unexpected problem processing request"
+                logging.error(errorMessage)
+                logging.info(e)
+
             self.task_done()
             sleep(0.5)
 


### PR DESCRIPTION
This PR improves exception handling in two ways.

Firstly, it cleans up the handling when logging into and sending messages via mastodon which should prevent this happening when mastodon times out.

Secondly, should some malformed message be delivered or some other area in the code where an unexpected exception slips though there is now a top level catch all exception handler in the job queue to prevent the (usually single) worker from dying.

I believe this fixes #13