### PR TITLE
Matrix capability integration

### DIFF
--- a/.ghi.yml.example
+++ b/.ghi.yml.example
@@ -1,23 +1,32 @@
 version: 1
 pools:
-  - name: pool-name
+  - name: "pool-name"
     github:
       repos:
-        - name: owner/repo
-          secret: abc123
+        - name: "owner/repo"
+          secret: "abc123"
     irc:
-      host: chat.freenode.net
-      nick: my-irc-bot
-      password: myBotPassword123!
+      host: "chat.freenode.net"
+      nick: "my-irc-bot"
+      password: "myBotPassword123!"
       channels:
-        - channel1
+        - "channel1"
     mastodon:
-      instance: https://mstdn.social
-      user: happy@place.net
-      password: myBotPassword123!
-      secretspath: /home/thatsme/my/secrets/
-      appname: my-mastodon-bot
+      instance: "https://mstdn.social"
+      user: "happy@place.net"
+      password: "myBotPassword123!"
+      secretspath: "/home/thatsme/my/mastodonsecrets/"
+      appname: "my-mastodon-bot"
       merges_only: True
+    matrix:
+      homeserver: "https://a.matrix.srv"
+      user: "@ghibot:matrix.srv"
+      password: "anotherGreatPassword456!"
+      secretspath: "/home/thatsme/my/matrixsecrets/"
+      device_id: "Ghi-Matrix-Bot"
+      rooms:
+        - "#room:matrix.srv"
     outlets:
-      - irc
-      - mastodon
+      - "irc"
+      - "mastodon"
+      - "matrix"

--- a/ghi/events/pull_request.py
+++ b/ghi/events/pull_request.py
@@ -5,6 +5,7 @@ import sys
 sys.path.append(os.path.dirname(os.path.realpath(__file__)) + "/../")
 import github
 from irc import Colors
+from util import matrix_html
 
 
 def PullRequest(payload, shorten):
@@ -53,10 +54,25 @@ def PullRequest(payload, shorten):
             url    = url
         )
 
+        matrixMessage = (
+            '[<font color="fuchsia">{repo}</font>] <font color="gray">{user}</font> <b>{action}</b> pull request <b>#{number}</b>: {title} '
+            '(<font color="purple">{baseBranch}</font>...<font color="purple">{headBranch}</font>) <font color="navy"><u>{url}</u></font>'
+        ).format(
+            repo         = matrix_html(payload["pull_request"]["base"]["repo"]["name"]),
+            user         = matrix_html(payload["sender"]["login"]),
+            action       = matrix_html(action),
+            number       = payload["number"],
+            title        = matrix_html(payload["pull_request"]["title"]),
+            baseBranch   = matrix_html(payload["pull_request"]["base"]["ref"]),
+            headBranch   = matrix_html(payload["pull_request"]["head"]["ref"]),
+            url          = url
+        )
+
         return {
             "statusCode": 200,
             "ircMessages": [ircMessage],
-            "mastMessages": [mastMessage]
+            "mastMessages": [mastMessage],
+            "matrixMessages": [matrixMessage]
         }
 
     else:

--- a/ghi/events/push.py
+++ b/ghi/events/push.py
@@ -5,6 +5,7 @@ import sys
 sys.path.append(os.path.dirname(os.path.realpath(__file__)) + "../")
 import github
 from irc import Colors
+from util import matrix_html
 
 
 def Push(payload, poolRepos, shorten):
@@ -54,22 +55,35 @@ def Push(payload, poolRepos, shorten):
             compareUrl = url
         )
 
+        matrixMessage = (
+            '[<font color="fuchsia">{repo}</font>] <font color="gray">{user}</font> {action} '
+            'tag <font color="purple">{tag}</font>: <font color="navy"><u>{compareUrl}</u></font>'
+        ).format(
+            repo         = matrix_html(payload["repository"]["name"]),
+            user         = matrix_html(payload["pusher"]["name"]),
+            action       = matrix_html(action),
+            tag          = matrix_html(ref.split("/", maxsplit=2)[2]),
+            compareUrl   = url
+        )
+
         return {
             "statusCode": 200,
             "ircMessages": [ircMessage],
-            "mastMessages": [mastMessage]
+            "mastMessages": [mastMessage],
+            "matrixMessages": [matrixMessage]
         }
 
     else:
         # Commits were pushed
-        ircMessages   = []
-        mastMessages  = []
-        commits       = payload["commits"]
-        repo          = payload["repository"]["name"]
-        fullName      = payload["repository"]["full_name"]
-        user          = payload["pusher"]["name"]
-        length        = len(commits)
-        branch        = ref.split("/", maxsplit=2)[2]
+        ircMessages    = []
+        mastMessages   = []
+        matrixMessages = []
+        commits        = payload["commits"]
+        repo           = payload["repository"]["name"]
+        fullName       = payload["repository"]["full_name"]
+        user           = payload["pusher"]["name"]
+        length         = len(commits)
+        branch         = ref.split("/", maxsplit=2)[2]
 
         # Check if the pool has allowed branches set.
         # If they do, make sure that this branch is included
@@ -143,13 +157,28 @@ def Push(payload, poolRepos, shorten):
             )
         )
 
+        matrixMessages.append(
+            '[<font color="fuchsia">{repo}</font>] <font color="gray">{user}</font> {action} '
+            '<b>{length}</b> commit{plural} to <font color="purple">{branch}</font>: '
+            '<font color="navy"><u>{compareUrl}</u></font>'.format(
+                repo         = matrix_html(repo),
+                user         = matrix_html(user),
+                action       = matrix_html(action),
+                length       = length,
+                branch       = matrix_html(branch),
+                compareUrl   = url,
+                plural       = matrix_html(plural)
+            )
+        )
+
         # First 3 individual commits
         num = 0
         for commit in commits:
             if num > 2:
                 break
-            # If commit message is longer than 75 characters, truncate.
-            commitMessage = commit["message"]
+            # We're only interested in the first line of the commit message, the title.
+            # If it is longer than 75 characters, truncate.
+            commitMessage = commit["message"].split('\n', 1)[0]
             author = commit["author"]["name"]
             if len(commitMessage) > 75:
                 commitMessage = commitMessage[0:74] + "..."
@@ -179,10 +208,22 @@ def Push(payload, poolRepos, shorten):
                 )
             )
 
+            matrixMessages.append(
+                '<font color="fuchsia">{repo}</font>/<font color="purple">{branch}</font> '
+                '<font color="gray">{shortCommit}</font> <font color="lightgrey">{user}</font>: {message}'.format(
+                    repo         = repo,
+                    branch       = branch,
+                    shortCommit  = commit["id"][0:7],
+                    user         = author,
+                    message      = commitMessage
+                )
+            )
+
             num += 1
 
         return {
             "statusCode": 200,
             "ircMessages": ircMessages,
-            "mastMessages": mastMessages
+            "mastMessages": mastMessages,
+            "matrixMessages": matrixMessages
         }

--- a/ghi/ghimatrix.py
+++ b/ghi/ghimatrix.py
@@ -1,0 +1,123 @@
+#!/usr/bin/env python3
+
+import asyncio
+import json
+import os
+import sys
+import logging
+
+try:
+    from nio import AsyncClient, LoginResponse
+    from nio.responses import RoomResolveAliasError
+except ImportError:
+    pass
+
+
+CRED_FILE = "ghi_matrix_credentials.json"
+
+
+def createCreds(resp: LoginResponse, homeserver, matrixSecFile) -> None:
+    """Writes the required login details to disk so we can log in later without
+    using a password.
+
+    Arguments:
+        resp {LoginResponse} -- the successful client login response.
+        homeserver -- URL of homeserver, e.g. "https://matrix.example.org"
+    """
+    # open the config file in write-mode
+    with open(matrixSecFile, "w") as f:
+        # write the login details to disk
+        json.dump(
+            {
+                "homeserver": homeserver,
+                "user_id": resp.user_id,
+                "device_id": resp.device_id,
+                "access_token": resp.access_token,
+            },
+            f,
+        )
+
+
+def sendMessages(*args, **kwargs) -> None:
+    return asyncio.run(_sendMessages(*args, **kwargs))
+
+
+async def _sendMessages(pool, messages) -> None:
+    homeserver = pool.matrixServer
+    user_id = pool.matrixUser
+    password = pool.matrixPassword
+    deviceName = pool.matrixDevId
+    credPath = pool.matrixSecPath
+    rooms = pool.matrixRooms
+
+    matrixSecFile = os.path.join(credPath, CRED_FILE)
+    # If there are no previously-saved credentials, we'll use the password
+    if not os.path.exists(matrixSecFile):
+        logging.info("First time use. Did not find credential file. Using info from config to create one.")
+
+        if not (homeserver.startswith("https://") or homeserver.startswith("http://")):
+            homeserver = "https://" + homeserver
+
+        client = AsyncClient(homeserver, user_id)
+
+        resp = await client.login(password, device_name=deviceName)
+
+        # check that we logged in successfully
+        if isinstance(resp, LoginResponse):
+            createCreds(resp, homeserver, matrixSecFile)
+        else:
+            logging.info(f'homeserver = "{homeserver}"; user = "{user_id}"')
+            logging.info(f"Failed to log in: {resp}")
+            sys.exit(1)
+
+        logging.info("Logged in using a password. Credentials were stored.")
+
+        await client.close()
+
+    with open(matrixSecFile, "r") as f:
+        config = json.load(f)
+        client = AsyncClient(config["homeserver"])
+
+        client.access_token = config["access_token"]
+        client.user_id = config["user_id"]
+        client.device_id = config["device_id"]
+
+        for room_id in rooms:
+            await client.join(room_id)
+            if room_id[0] != "!":
+                response = await client.room_resolve_alias(room_id)
+
+                if isinstance(response, RoomResolveAliasError):
+                    logging.info(f"Error looking up alias for {room_id}: {response}")
+                    return {
+                        "statusCode": 500,
+                        "body": json.dumps({
+                            "success": False,
+                            "message": "An error happened while sending messages to Matrix"
+                        })
+                    }
+
+                room_id = response.room_id
+
+            for message in messages:
+                await client.room_send(
+                    room_id,
+                    message_type="m.room.message",
+                    content={"msgtype": "m.text", "body": "", "format": "org.matrix.custom.html", "formatted_body":message},
+                )
+
+    await client.close()
+
+    if len(messages) == 1:
+        resultMessage = "Matrix - Successfully sent 1 message."
+    else:
+        resultMessage = "Matrix - Successfully sent {} messages.".format(len(messages))
+
+    logging.info(resultMessage)
+    return {
+        "statusCode": 200,
+        "body": json.dumps({
+            "success": True,
+            "message": resultMessage
+        })
+    }

--- a/ghi/github.py
+++ b/ghi/github.py
@@ -82,7 +82,8 @@ def parsePayload(event, payload, repos, shorten):
         return {
             "statusCode": 200,
             "ircMessages": push["ircMessages"],
-            "mastMessages": push["mastMessages"]
+            "mastMessages": push["mastMessages"],
+            "matrixMessages": push["matrixMessages"]
         }
 
 
@@ -95,7 +96,8 @@ def parsePayload(event, payload, repos, shorten):
         return {
             "statusCode": 200,
             "ircMessages": pullRequest["ircMessages"],
-            "mastMessages": pullRequest["mastMessages"]
+            "mastMessages": pullRequest["mastMessages"],
+            "matrixMessages": pullRequest["matrixMessages"]
         }
 
 

--- a/ghi/util.py
+++ b/ghi/util.py
@@ -1,0 +1,10 @@
+def matrix_html(msg):
+    '''
+    Escape text for matrix HTML.
+    '''
+    # This should be html.escape. however, the Matrix→IRC bridge currently eats
+    # everything that looks like HTML, even escaped. So go for a solution that
+    # works for our particular case: simply strip characters that the bridge
+    # has difficulty with (escaped and unescaped).
+    # See https://github.com/matrix-org/matrix-appservice-irc/issues/1562.
+    return msg.replace('<', '').replace('>', '').replace('&lt;', '').replace('&gt;', '')

--- a/requirements-server.txt
+++ b/requirements-server.txt
@@ -2,3 +2,4 @@ PyYAML~=5.4
 requests~=2.26
 tornado~=6.1
 mastodon-py~=1.5
+matrix-nio~=0.19


### PR DESCRIPTION
To support Matrix as an outlet for ghi we:

- edited `ghi/configuration.py` to read, check and use the (optional) Matrix-settings from the .yml-config
- created `ghi/ghimatrix.py` to facilitate creating credential-files, logging onto a Matrix server and sending messages to one or more rooms on it by using the matrix-nio module
- changed some naming and matrix-specific things in most of the files
- changed the `README.md` en `.ghy.yml.example` to include the new Matrix-support
- created `ghi/util.py` to facilitate in a workaround for a Matrix-issue (https://github.com/matrix-org/matrix-appservice-irc/issues/1562)
- added relevant exception-handlers

No changes to the config-file are necessary when using IRC.

It works quite well with `ghi/server.py`, haven't tested it with AWS though, but should work as well.

Closes #27

Co-authored-by: W. J. van der Laan <laanwj@protonmail.com>